### PR TITLE
Added ability to double click to open files

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -21,6 +21,7 @@ tauri = { version = "1.7.0", features = [] }
 chrono = {version = "0.4", features = ["serde"] }
 regex = "1.10.6"
 sys = "0.0.1"
+open = "3.2.0"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem and the built-in dev server is disabled.

--- a/frontend/components/results/ResultRow.vue
+++ b/frontend/components/results/ResultRow.vue
@@ -1,5 +1,5 @@
 <template>
-  <tr class="result-row" @dblclick.prevent="resultEvent">
+  <tr class="result-row" @dblclick.prevent="doResultEvent">
     <td>
       <div class="result-icon">
         <slot/>
@@ -18,6 +18,7 @@
 </template>
 <script>
 import { invoke } from '@tauri-apps/api';
+import FileType from './enum/FileType.js'
 export default {
   props: {
     path: String,
@@ -26,10 +27,11 @@ export default {
     type: String,
   },
   methods: {
-    resultEvent() {
-      if (this.type === "Directory") {
+    doResultEvent() {
+      console.log(FileType.Directory);
+      if (this.type === FileType.Directory) {
         this.pathEmitter.emit("path-update", this.path);
-      } else if (this.type === "File") {
+      } else if (this.type === FileType.File) {
         invoke("open_file", { file_path: this.path }).then((response) => {
           console.log(response);
         });

--- a/frontend/components/results/ResultRow.vue
+++ b/frontend/components/results/ResultRow.vue
@@ -1,5 +1,5 @@
 <template>
-  <tr class="result-row" @dblclick.prevent="updatePath">
+  <tr class="result-row" @dblclick.prevent="resultEvent">
     <td>
       <div class="result-icon">
         <slot/>
@@ -26,7 +26,7 @@ export default {
     type: String,
   },
   methods: {
-    updatePath() {
+    resultEvent() {
       if (this.type === "Directory") {
         this.pathEmitter.emit("path-update", this.path);
       } else if (this.type === "File") {

--- a/frontend/components/results/ResultRow.vue
+++ b/frontend/components/results/ResultRow.vue
@@ -17,7 +17,7 @@
   </tr>
 </template>
 <script>
-
+import { invoke } from '@tauri-apps/api';
 export default {
   props: {
     path: String,
@@ -29,6 +29,10 @@ export default {
     updatePath() {
       if (this.type === "Directory") {
         this.pathEmitter.emit("path-update", this.path);
+      } else if (this.type === "File") {
+        invoke("open_file", { file_path: this.path }).then((response) => {
+          console.log(response);
+        });
       }
     },
   }

--- a/frontend/components/results/enum/FileType.js
+++ b/frontend/components/results/enum/FileType.js
@@ -1,0 +1,7 @@
+// eslint-disable-next-line
+const FileType = {
+  File: "File",
+  Directory: "Directory",
+  Link: "Link",
+  BrokenLink: "BrokenLink",
+};


### PR DESCRIPTION
Uses system 'default' app to open
Also no longer crashes if it encounters broken symlinks
 - now instead marks the result name with ' - broken symlink'
 - opening (double click) does nothing as the path for the result is set to the current directory path